### PR TITLE
Adding jsPDF plugin wire-up

### DIFF
--- a/svgToPdf.js
+++ b/svgToPdf.js
@@ -205,4 +205,19 @@ var svgElementToPdf = function(element, pdf, options) {
         }
     });
     return pdf;
-}
+};
+
+(function(jsPDFAPI) {
+'use strict';
+    
+  jsPDFAPI.addSVG = function(element, x, y, options) {
+    'use strict'
+
+    options = (typeof(options) == 'undefined' ? {} : options);
+    options.x_offset = x;
+    options.y_offset = y;
+
+    svgElementToPdf(element, this, options);
+    return this;
+  };
+})(jsPDF.API);


### PR DESCRIPTION
With this change, code like this becomes possible:

```
var pdf = new jsPDF();
pdf.addSVG(svgData, 25, 50, options);
```

In comparison, without this change, something along the lines of the below is required:

```
var pdf = new jsPDF();
svgElementToPdf(svgData, pdf, { x_offset: 25, y_offset: 50 });
```

_Note_
The method name "addSVG" conflicts with https://github.com/MrRio/jsPDF/blob/master/jspdf.plugin.sillysvgrenderer.js. This isn't a problem so long as we presume that the user will only use one SVG rendering plugin at a time.
