### PR TITLE
Bug fix for remove attribute functionality

### DIFF
--- a/svgToPdf.js
+++ b/svgToPdf.js
@@ -41,6 +41,7 @@ var removeAttributes = function(node, attributes) {
         node.removeAttribute(a.name);
     });	
 }
+
 var svgElementToPdf = function(element, pdf, options) {
     // pdf is a jsPDF object
     //console.log("options =", options);
@@ -92,7 +93,7 @@ var svgElementToPdf = function(element, pdf, options) {
             case 'a':
             case 'g':
                 svgElementToPdf(node, pdf, options);
-		removeAttributes(node, pdfSvgAttr.g);
+                removeAttributes(node, pdfSvgAttr.g);
                 break;
             case 'line':
                 pdf.line(
@@ -111,7 +112,7 @@ var svgElementToPdf = function(element, pdf, options) {
                     k*parseInt(n.attr('height')),
                     colorMode
                 );
-		removeAttributes(node, pdfSvgAttr.rect);
+                removeAttributes(node, pdfSvgAttr.rect);
                 break;
             case 'ellipse':
                 pdf.ellipse(
@@ -121,7 +122,7 @@ var svgElementToPdf = function(element, pdf, options) {
                     k*parseInt(n.attr('ry')),
                     colorMode
                 );
-		removeAttributes(node, pdfSvgAttr.ellipse);
+                removeAttributes(node, pdfSvgAttr.ellipse);
                 break;
             case 'circle':
                 pdf.circle(
@@ -130,7 +131,7 @@ var svgElementToPdf = function(element, pdf, options) {
                     k*parseInt(n.attr('r')),
                     colorMode
                 );
-		removeAttributes(node, pdfSvgAttr.circle);
+                removeAttributes(node, pdfSvgAttr.circle);
                 break;
             case 'text':
                 if(node.hasAttribute('font-family')) {
@@ -184,7 +185,7 @@ var svgElementToPdf = function(element, pdf, options) {
                     k * y,
                     n.text()
                 );
-		removeAttributes(node, pdfSvgAttr.text);
+                removeAttributes(node, pdfSvgAttr.text);
                 break;
             //TODO: image
             default:


### PR DESCRIPTION
Without this patch, if SVG containing attributes not in `pdfSvgAttr` is rendered with option _removeInvalid_ set to true, an `Unable to get property 'name' of undefined or null reference` error may be encountered. 

This patch fixes this issue. 
## Cause

Code such as the following which deletes items from the attribute collection **while iterating through that same collection:**

```
$.each(node.attributes, function(i, a) {
    if(typeof(a) != 'undefined' && pdfSvgAttr.g.indexOf(a.name.toLowerCase()) == -1) {
    node.removeAttribute(a.name);
    }
});
```
## Example

In the below code, rendering any immediate child of `<svg>` using IE11 (Windows 7 Pro) causes an `Unable to get property 'name' of undefined or null reference` error.

```
<svg id="score" style="overflow: hidden; position: relative;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="720" version="1.1" height="288">
    <text invalid-attribute-one="true" invalid-attribute-two="true" x="20" y="140" font-family="serif" font-style="italic" fill="black">Some Text</text>
    <rect invalid-attribute-one="true" invalid-attribute-two="true" x="14" y="23" width="150" height="77" fill="lime"
          stroke="black" stroke-width="1"></rect>
    <circle invalid-attribute-one="true" invalid-attribute-two="true"  cx="220" cy="100" r="50" stroke="black"
        stroke-width="5" fill="red"></circle>
    <ellipse invalid-attribute-one="true" invalid-attribute-two="true"  cx="158" cy="169" rx="75" ry="20"></ellipse>
    <line invalid-attribute-one="true" invalid-attribute-two="true"  x1="0" y1="0" x2="200" y2="200"></line>
    <g invalid-attribute-one="true" invalid-attribute-two="true">
        <circle cx="25" cy="25" r="15"></circle>
        <circle cx="40" cy="25" r="15"></circle>
    </g>
</svg>
```
